### PR TITLE
Rename repository to PQC-LEO and update references 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,5 @@ tmp/
 /temp_storage/
 __pycache__/
 /test_data/
-/.pqc_eval_dir_marker.tmp
+/.pqc_leo_dir_marker.tmp
 /dev-scripts

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -37,5 +37,5 @@ If HQC is enabled:
 For more information, see:
 - [Liboqs Pull Request #2122](https://github.com/open-quantum-safe/liboqs/pull/2122)
 - [Liboqs Issue #2118](https://github.com/open-quantum-safe/liboqs/issues/2118)
-- [PQC-Evaluation-Tools Issue #46](https://github.com/crt26/pqc-evaluation-tools/issues/46)
-- [PQC-Evaluation-Tools Issue #60](https://github.com/crt26/pqc-evaluation-tools/issues/60)
+- [PQC-LEO Issue #46](https://github.com/crt26/PQC-LEO/issues/46)
+- [PQC-LEO Issue #60](https://github.com/crt26/PQC-LEO/issues/60)

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -25,7 +25,7 @@ Users are responsible for ensuring compliance with all relevant third-party lice
 ## HQC Algorithm Inclusion Disclaimer
 The HQC KEM algorithms are disabled by default in both Liboqs and OQS-Provider due to the current implementation not conforming to the latest reference specification. This includes fixes for a previously identified security flaw that breaks IND-CCA2 guarantees under specific attack models.
 
-As a result, the PQC Evaluation Tools framework provides an optional mechanism to enable HQC **solely for benchmarking purposes**. Users who choose to enable HQC will be warned about the associated risks and must explicitly acknowledge and confirm their decision to proceed. Please refer to the [Advanced Setup Configuration](docs/advanced_setup_configuration.md) for details on enabling HQC.
+As a result, the PQC-LEO framework provides an optional mechanism to enable HQC **solely for benchmarking purposes**. Users who choose to enable HQC will be warned about the associated risks and must explicitly acknowledge and confirm their decision to proceed. Please refer to the [Advanced Setup Configuration](docs/advanced_setup_configuration.md) for details on enabling HQC.
 
 Enabling HQC is done at the user's discretion, and users will be required to explicitly acknowledge the risks and confirm that they wish to proceed. The project maintainers make no guarantees about the correctness, security, or compliance of HQC as currently implemented in the OQS libraries. Enabling HQC is done entirely at your own risk, and this project assumes no responsibility for any issues that may arise from its use.
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Once all the relevant options have been selected, the setup script will download
 > † Enabling all signature algorithms may cause the OpenSSL speed tool to fail due to internal limits in its source code. The setup script attempts to patch this automatically, but you can configure this process manually. Please refer to the [Advanced Setup Configuration](docs/advanced_setup_configuration.md) for further details.
 
 ### Ensuring Root Dir Path Marker is Present
-A hidden file named `.pqc_eval_dir_marker.tmp` is created in the project's root directory during setup. Automation scripts use this marker to reliably identify the root path, which is essential for their correct operation.
+A hidden file named `.pqc_leo_dir_marker.tmp` is created in the project's root directory during setup. Automation scripts use this marker to reliably identify the root path, which is essential for their correct operation.
 
 When running the setup script, it is vital that this is done from the root of the repository so that this file is placed correctly. 
 
@@ -157,7 +157,7 @@ ls -la
 To manually recreate the file, run the following command from the project's root directory:
 
 ```
-touch .pqc_eval_dir_marker.tmp
+touch .pqc_leo_dir_marker.tmp
 ```
 
 ### Optional Setup Flags

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Notice: <!-- omit from toc -->
 This is the **development branch**; it may not be in a fully functioning state, and the documentation may still need to be updated. The checkboxes below indicate whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless, please keep this in mind and use the main branch if possible. Thank you.
 
-- [ ] Functioning State
-- [ ] Up-to-date documentation
+- [x] Functioning State
+- [x] Up-to-date documentation
 
 ### Main Development Branch Task Tracking
 For full details on the project's development and the current development task lists, please refer to the repository's Github Projects Page here:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PQC-Evaluation-Tools <!-- omit from toc -->
+# PQC-LEO <!-- omit from toc -->
 
 ## Notice: <!-- omit from toc -->
 This is the **development branch**; it may not be in a fully functioning state, and the documentation may still need to be updated. The checkboxes below indicate whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless, please keep this in mind and use the main branch if possible. Thank you.
@@ -9,14 +9,20 @@ This is the **development branch**; it may not be in a fully functioning state, 
 ### Main Development Branch Task Tracking
 For full details on the project's development and the current development task lists, please refer to the repository's Github Projects Page here:
 
-[PQC-Evaluation-Tools Project Page](https://github.com/users/crt26/projects/2)
+[PQC-LEO Project Page](https://github.com/users/crt26/projects/2)
 
 ### Project Description
-This repository provides an automated and comprehensive evaluation framework for benchmarking Post-Quantum Cryptography (PQC) algorithms. It is designed for researchers and developers looking to evaluate the feasibility of integrating PQC into their environments. The framework streamlines the setup and testing of PQC implementations, enabling the collection of computational and networking performance metrics across x86 and ARM systems through a suite of dedicated automation scripts.
+PQC-LEO (PQC-Library Evaluation Operator) provides an automated and comprehensive evaluation framework for benchmarking Post-Quantum Cryptography (PQC) algorithms. It is designed for researchers and developers looking to evaluate the feasibility of integrating PQC into their environments. The framework streamlines the setup and testing of PQC implementations, enabling the collection of computational and networking performance metrics across x86 and ARM systems through a suite of dedicated automation scripts.
 
 PQC implementations are sourced from multiple libraries, including algorithms natively supported in OpenSSL 3.5.0 and those available from the [Open Quantum Safe (OQS)](https://openquantumsafe.org/) project's `Liboqs` and `OQS-Provider` libraries. The framework also provides automated mechanisms for testing PQC TLS handshake performance across physical or virtual networks, providing valuable insight into real-world environment testing. Results are outputted as raw CSV files that are automatically processed using the provided Python parsing scripts to provide detailed metrics and averages ready for analysis.
 
 Future versions of the project aim to support additional PQC libraries, further expanding the scope of supported benchmarking.
+
+>**Migration Notice:** 
+>
+>This project has been **renamed** from pqc-evaluation-tools to PQC-LEO.
+>
+> **Please update** any existing local clones to reference the new repository name. This notice will be removed at the release of the next major version. 
 
 ### Supported Automation Functionality
 The project provides automation for:
@@ -36,7 +42,7 @@ The project provides automation for:
 ### Project Development
 For details on the project's development and upcoming features, see the project's GitHub Projects page:
 
-[PQC-Evaluation-Tools Project Page](https://github.com/users/crt26/projects/2)
+[PQC-LEO Project Page](https://github.com/users/crt26/projects/2)
 
 ## Contents <!-- omit from toc -->
 - [Supported Hardware and Software](#supported-hardware-and-software)
@@ -98,13 +104,13 @@ The following instructions describe the standard setup process, which is the def
 Clone the current stable version:
 
 ```
-git clone https://github.com/crt26/pqc-evaluation-tools.git
+git clone https://github.com/crt26/PQC-LEO.git
 ```
 
 Move into the cloned repository directory and execute the setup script:
 
 ```
-cd pqc-evaluation-tools
+cd PQC-LEO
 ./setup.sh
 ```
 
@@ -235,7 +241,7 @@ Links below provide access to the various internal project documentation. Howeve
 ### Project Wiki Page <!-- omit from toc -->
 The information provided in the internal documentation is also available through the project's GitHub Wiki:
 
-[PQC-Evaluation-Tools Wiki](https://github.com/crt26/pqc-evaluation-tools/wiki)
+[PQC-LEO Wiki](https://github.com/crt26/PQC-LEO/wiki)
 
 ### Helpful External Documentation Links <!-- omit from toc -->
 - [Liboqs Webpage](https://openquantumsafe.org/liboqs/)

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Notice: <!-- omit from toc -->
 This is the **development branch**; it may not be in a fully functioning state, and the documentation may still need to be updated. The checkboxes below indicate whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless, please keep this in mind and use the main branch if possible. Thank you.
 
-- [x] Functioning State
-- [x] Up-to-date documentation
+- [ ] Functioning State
+- [ ] Up-to-date documentation
 
 ### Main Development Branch Task Tracking
 For full details on the project's development and the current development task lists, please refer to the repository's Github Projects Page here:

--- a/cleaner.sh
+++ b/cleaner.sh
@@ -59,11 +59,11 @@ function setup_base_env() {
     # Try and find the .dir_marker.tmp file to determine the project's root directory
     current_dir="$script_dir"
 
-    # Continue moving up the directory tree until the .pqc_eval_dir_marker.tmp file is found
+    # Continue moving up the directory tree until the .pqc_leo_dir_marker.tmp file is found
     while true; do
 
-        # Check if the .pqc_eval_dir_marker.tmp file is present
-        if [ -f "$current_dir/.pqc_eval_dir_marker.tmp" ]; then
+        # Check if the .pqc_leo_dir_marker.tmp file is present
+        if [ -f "$current_dir/.pqc_leo_dir_marker.tmp" ]; then
             root_dir="$current_dir"  # Set root_dir to the directory, not including the file name
             break
         fi
@@ -161,7 +161,7 @@ function select_uninstall_mode() {
             4)
                 # Uninstall all dependency libraries
                 rm -rf "$libs_dir" && rm -rf "$tmp_dir" && rm -rf "$dependency_dir"
-                rm -rf "$root_dir/.pqc_eval_dir_marker.tmp"
+                rm -rf "$root_dir/.pqc_leo_dir_marker.tmp"
                 rm -rf "$test_data_alg_lists_dir"
                 echo -e "\nAll Libraries Uninstalled"
                 break;;

--- a/docs/advanced_setup_configuration.md
+++ b/docs/advanced_setup_configuration.md
@@ -27,7 +27,7 @@ By default, the main setup script will attempt to detect and patch these values 
 
 Replace [integer] with the desired value. The setup script will then patch the `speed.c` source file to set both `MAX_KEM_NUM` and `MAX_SIG_NUM` to this value before compiling OpenSSL.
 
-For further details on this issue and the plans to address the problem in the future, please refer to this [git issue](https://github.com/crt26/pqc-evaluation-tools/issues/25) on the repositories page.
+For further details on this issue and the plans to address the problem in the future, please refer to this [git issue](https://github.com/crt26/PQC-LEO/issues/25) on the repositories page.
 
 ## Enabling HQC KEM Algorithms in Liboqs and OQS-Provider
 Recent versions of both Liboqs and OQS-Provider disable HQC KEM algorithms by default, due to their current implementations not conforming to the latest specification, which includes important security fixes. This project provides optional setup flags to re-enable HQC **strictly for benchmarking purposes**, with full user awareness and consent. When enabling HQC, the setup script will display a security warning and require confirmation before continuing. If declined, HQC remains disabled.
@@ -58,6 +58,6 @@ If HQC is enabled (depending on which enable type is selected):
 For additional context, please see:
 - [Liboqs Pull Request #2122](https://github.com/open-quantum-safe/liboqs/pull/2122)
 - [Liboqs Issue #2118](https://github.com/open-quantum-safe/liboqs/issues/2118)
-- [PQC-Evaluation-Tools Issue #46](https://github.com/crt26/pqc-evaluation-tools/issues/46)
-- [PQC-Evaluation-Tools Issue #60](https://github.com/crt26/pqc-evaluation-tools/issues/60)
+- [PQC-LEO Issue #46](https://github.com/crt26/PQC-LEO/issues/46)
+- [PQC-LEO Issue #60](https://github.com/crt26/PQC-LEO/issues/60)
 - [Disclaimer Document](../DISCLAIMER.md)

--- a/docs/developer_information/project_dependencies.md
+++ b/docs/developer_information/project_dependencies.md
@@ -1,7 +1,7 @@
 # Project Dependencies <!-- omit from toc -->
 
 ## Document Overview <!-- omit from toc -->
-This document provides a comprehensive overview of the dependencies required to build and run the PQC-Evaluation-Tools suite. Installation and management of these dependencies are fully automated and handled during execution of the main setup script.
+This document provides a comprehensive overview of the dependencies required to build and run the PQC-LEO suite. Installation and management of these dependencies are fully automated and handled during execution of the main setup script.
 
 While this information is primarily intended for developers and contributors who need insight into the project's build and runtime environment, it may also be helpful for users who wish to override the default cryptographic library versions.
 
@@ -26,7 +26,7 @@ The automated testing tool is currently only supported in the following environm
 - ARM Linux devices using a 64-bit Debian-based Operating System
 
 ## Cryptographic Dependency Libraries
-This document lists the **specific commits** used as the last tested versions of the project's core dependencies. These versions are pinned by default during setup to ensure compatibility with the PQC-Evaluation-Tools benchmarking framework.
+This document lists the **specific commits** used as the last tested versions of the project's core dependencies. These versions are pinned by default during setup to ensure compatibility with the PQC-LEO benchmarking framework.
 
 ### Last Tested Versions <!-- omit from toc -->
 
@@ -45,7 +45,7 @@ For setup instructions and details on using the latest cryptographic dependency 
 - [Advanced Setup Configuration](../advanced_setup_configuration.md)
 
 ## System Package Dependencies
-The following system-level packages are required for building and running the PQC-Evaluation-Tools suite. These are automatically checked and installed using the apt package manager during the setup process.
+The following system-level packages are required for building and running the PQC-LEO framework. These are automatically checked and installed using the apt package manager during the setup process.
 
 By default, the setup script will install the latest available versions of these packages from the distribution's package repositories if they are not already present on the system.
 

--- a/docs/developer_information/repository_directory_structure.md
+++ b/docs/developer_information/repository_directory_structure.md
@@ -1,15 +1,15 @@
 # Repository Directory Structure
 
 ## Overview
-This document outlines the directory structure of the `PQC-Evaluation-Tools` repository. It includes both the default contents available upon cloning and the directories that are dynamically generated during operation.
+This document outlines the directory structure of the `PQC-LEO` repository. It includes both the default contents available upon cloning and the directories that are dynamically generated during operation.
 
 Directories created by scripts during execution are marked with an asterisk (`*`) in the directory layout diagram.
 
 ## Layout and Descriptions
-The `PQC-Evaluation-Tools` repository directories are organised as follows:
+The `PQC-LEO` repository directories are organised as follows:
 
 ```
-pqc-evaluation-tools/
+PQC-LEO/
 │
 ├── docs/
 │   ├── developer_information/

--- a/docs/performance_results/parsing_scripts_usage_guide.md
+++ b/docs/performance_results/parsing_scripts_usage_guide.md
@@ -1,7 +1,7 @@
 # Parsing Scripts Usage Guide <!-- omit from toc -->
 
 ## Document Overview <!-- omit from toc -->
-This document provides a comprehensive guide to the usage of the result parsing functionality included in the PQC-Evaluation-Tools project. It explains how the parsing system processes raw benchmarking output data into structured results, and how users can interact with the parsing system in both automated and manual modes.
+This document provides a comprehensive guide to the usage of the result parsing functionality included in the PQC-LEO project. It explains how the parsing system processes raw benchmarking output data into structured results, and how users can interact with the parsing system in both automated and manual modes.
 
 It also outlines the expected directory structure for test results, limitations of the current implementation, and how to manually invoke the parsing process using the provided Python scripts.
 
@@ -15,7 +15,7 @@ It also outlines the expected directory structure for test results, limitations 
 - [Current Parsing Limitations](#current-parsing-limitations)
 
 ## Parsing Overview
-The parsing system in PQC-Evaluation-Tools transforms raw test output into structured CSV files that are ready for analysis. Parsing can happen automatically at the end of each test run or be invoked manually later using the provided controller script. Parsed results are categorised by test type (computational performance or TLS performance) and Machine-ID, and are saved into separate result folders under the main `test_data` directory.
+The parsing system in PQC-LEO transforms raw test output into structured CSV files that are ready for analysis. Parsing can happen automatically at the end of each test run or be invoked manually later using the provided controller script. Parsed results are categorised by test type (computational performance or TLS performance) and Machine-ID, and are saved into separate result folders under the main `test_data` directory.
 
 The automated testing scripts provided by this project will automatically call the Python parsing scripts once testing is completed and supply the testing parameters used. However, the user may decide to disable this feature and call the parsing scripts manually.
 

--- a/docs/supported_algorithms.md
+++ b/docs/supported_algorithms.md
@@ -1,7 +1,7 @@
 # Supported PQC Algorithms <!-- omit from toc -->
 
 ## Support Overview <!-- omit from toc -->
-This document outlines the Key Encapsulation Mechanisms (KEMs) and digital signature algorithms supported by this project, based on its upstream cryptographic dependencies: Liboqs, OQS-Provider, and OpenSSL. While the PQC-Evaluation-Tools project integrates nearly all algorithms from these libraries, there are a few exceptions.
+This document outlines the Key Encapsulation Mechanisms (KEMs) and digital signature algorithms supported by this project, based on its upstream cryptographic dependencies: Liboqs, OQS-Provider, and OpenSSL. While the PQC-LEO project integrates nearly all algorithms from these libraries, there are a few exceptions.
 
 It contains comprehensive lists of all supported PQC algorithms, along with any exclusions and the rationale behind them.
 
@@ -38,7 +38,7 @@ Although the OQS-Provider depends on Liboqs for algorithm implementations, it ex
 ## Liboqs Algorithms
 
 ### Algorithm Support Summary
-The PQC-Evaluation-Tools project supports all key encapsulation mechanisms (KEMs) and digital signature algorithms provided by Liboqs, with three notable exceptions:
+The PQC-LEO project supports all key encapsulation mechanisms (KEMs) and digital signature algorithms provided by Liboqs, with three notable exceptions:
 
 - **HQC** -  its variants are disabled by default in both Liboqs and the OQS-Provider due to their current implementations not conforming to the latest specification, which includes important security fixes. As a result, HQC algorithms are excluded from all performance benchmarking unless explicitly enabled by the user using dedicated flags during the setup process.
 
@@ -226,7 +226,7 @@ Certain variations of the supported digital signature schemes are excluded from 
 - **SNOVA Scheme Variations**
 - **CROSSrsdp256small**
 
-These schemes remain available for use in the TLS speed tests that the PQC-Evaluation-Tools provides using the OpenSSL `speed` tool. 
+These schemes remain available for use in the TLS speed tests that the PQC-LEO provides using the OpenSSL `speed` tool. 
 
 Whilst a significant number of these scheme variations can not be used in TLS Handshake testing, there are the following exceptions:
 

--- a/scripts/parsing_scripts/internal_scripts/performance_data_parse.py
+++ b/scripts/parsing_scripts/internal_scripts/performance_data_parse.py
@@ -29,7 +29,7 @@ def setup_parse_env(root_dir):
     dir_paths = {}
 
     # Ensure the root_dir path is correct before continuing
-    if not os.path.isfile(os.path.join(root_dir, ".pqc_eval_dir_marker.tmp")):
+    if not os.path.isfile(os.path.join(root_dir, ".pqc_leo_dir_marker.tmp")):
         print("Project root directory path file not correct, the main parse_results.py file is not able to establish the correct path!!!")
         sys.exit(1)
 

--- a/scripts/parsing_scripts/internal_scripts/tls_performance_data_parse.py
+++ b/scripts/parsing_scripts/internal_scripts/tls_performance_data_parse.py
@@ -25,7 +25,7 @@ def setup_parse_env(root_dir):
     dir_paths = {}
 
     # Ensure the root_dir path is correct before continuing
-    if not os.path.isfile(os.path.join(root_dir, ".pqc_eval_dir_marker.tmp")):
+    if not os.path.isfile(os.path.join(root_dir, ".pqc_leo_dir_marker.tmp")):
         print("Project root directory path file not correct, the main parse_results.py file is not able to establish the correct path!!!")
         sys.exit(1)
 

--- a/scripts/parsing_scripts/parse_results.py
+++ b/scripts/parsing_scripts/parse_results.py
@@ -23,7 +23,7 @@ def handle_args():
         Raises errors and exits if arguments are invalid. """
     
     # Define the argument parser and the valid options for the script
-    parser = argparse.ArgumentParser(description="PQC-Evaluation-Tools Results Parsing Tool")
+    parser = argparse.ArgumentParser(description="PQC-LEO Results Parsing Tool")
     parser.add_argument('--parse-mode', type=str, help='The parsing mode to be used (computational or tls)')
     parser.add_argument('--machine-id', type=int, help='The Machine-ID of the results to be parsed')
     parser.add_argument('--total-runs', type=int, help='The number of test runs to be parsed')
@@ -195,7 +195,7 @@ def main():
     else:
 
         # Output the greeting message to the terminal
-        print(f"PQC-Evaluation-Tools Results Parsing Tool\n")
+        print(f"PQC-LEO Results Parsing Tool\n")
 
         # Get the parsing mode from the user
         user_parse_mode = get_mode_selection()

--- a/scripts/parsing_scripts/parse_results.py
+++ b/scripts/parsing_scripts/parse_results.py
@@ -71,18 +71,18 @@ def handle_args():
 #------------------------------------------------------------------------------------------------------------------------------
 def setup_base_env():
     """ Function for setting up the global environment by determining the root path. It recursively moves up the directory 
-        tree until it finds the .pqc_eval_dir_marker.tmp file, then returns the root path. """
+        tree until it finds the .pqc_leo_dir_marker.tmp file, then returns the root path. """
 
     
     # Determine the directory that the script is being executed from and set the marker filename
     script_dir = os.path.dirname(os.path.abspath(__file__))
     current_dir = script_dir
-    marker_filename = ".pqc_eval_dir_marker.tmp"
+    marker_filename = ".pqc_leo_dir_marker.tmp"
 
-    # Continue moving up the directory tree until the .pqc_eval_dir_marker.tmp file is found
+    # Continue moving up the directory tree until the .pqc_leo_dir_marker.tmp file is found
     while True:
 
-        # Check if the .pqc_eval_dir_marker.tmp file is present
+        # Check if the .pqc_leo_dir_marker.tmp file is present
         if os.path.isfile(os.path.join(current_dir, marker_filename)):
             root_dir = current_dir
             return root_dir

--- a/scripts/test_scripts/internal_scripts/tls_handshake_test_client.sh
+++ b/scripts/test_scripts/internal_scripts/tls_handshake_test_client.sh
@@ -24,11 +24,11 @@ function setup_base_env() {
     # Try and find the .dir_marker.tmp file to determine the project's root directory
     current_dir="$script_dir"
 
-    # Continue moving up the directory tree until the .pqc_eval_dir_marker.tmp file is found
+    # Continue moving up the directory tree until the .pqc_leo_dir_marker.tmp file is found
     while true; do
 
-        # Check if the .pqc_eval_dir_marker.tmp file is present
-        if [ -f "$current_dir/.pqc_eval_dir_marker.tmp" ]; then
+        # Check if the .pqc_leo_dir_marker.tmp file is present
+        if [ -f "$current_dir/.pqc_leo_dir_marker.tmp" ]; then
             root_dir="$current_dir"
             break
         fi

--- a/scripts/test_scripts/internal_scripts/tls_handshake_test_server.sh
+++ b/scripts/test_scripts/internal_scripts/tls_handshake_test_server.sh
@@ -22,11 +22,11 @@ function setup_base_env() {
     # Try and find the .dir_marker.tmp file to determine the project's root directory
     current_dir="$script_dir"
 
-    # Continue moving up the directory tree until the .pqc_eval_dir_marker.tmp file is found
+    # Continue moving up the directory tree until the .pqc_leo_dir_marker.tmp file is found
     while true; do
 
-        # Check if the .pqc_eval_dir_marker.tmp file is present
-        if [ -f "$current_dir/.pqc_eval_dir_marker.tmp" ]; then
+        # Check if the .pqc_leo_dir_marker.tmp file is present
+        if [ -f "$current_dir/.pqc_leo_dir_marker.tmp" ]; then
             root_dir="$current_dir"
             break
         fi

--- a/scripts/test_scripts/internal_scripts/tls_speed_test.sh
+++ b/scripts/test_scripts/internal_scripts/tls_speed_test.sh
@@ -23,11 +23,11 @@ function setup_test_env() {
     # Try and find the .dir_marker.tmp file to determine the project's root directory
     current_dir="$script_dir"
 
-    # Continue moving up the directory tree until the .pqc_eval_dir_marker.tmp file is found
+    # Continue moving up the directory tree until the .pqc_leo_dir_marker.tmp file is found
     while true; do
 
-        # Check if the .pqc_eval_dir_marker.tmp file is present
-        if [ -f "$current_dir/.pqc_eval_dir_marker.tmp" ]; then
+        # Check if the .pqc_leo_dir_marker.tmp file is present
+        if [ -f "$current_dir/.pqc_leo_dir_marker.tmp" ]; then
             root_dir="$current_dir"  # Set root_dir to the directory, not including the file name
             break
         fi

--- a/scripts/test_scripts/pqc_performance_test.sh
+++ b/scripts/test_scripts/pqc_performance_test.sh
@@ -211,11 +211,11 @@ function setup_base_env() {
     # Try and find the .dir_marker.tmp file to determine the project's root directory
     current_dir="$script_dir"
 
-    # Continue moving up the directory tree until the .pqc_eval_dir_marker.tmp file is found
+    # Continue moving up the directory tree until the .pqc_leo_dir_marker.tmp file is found
     while true; do
 
-        # Check if the .pqc_eval_dir_marker.tmp file is present
-        if [ -f "$current_dir/.pqc_eval_dir_marker.tmp" ]; then
+        # Check if the .pqc_leo_dir_marker.tmp file is present
+        if [ -f "$current_dir/.pqc_leo_dir_marker.tmp" ]; then
             root_dir="$current_dir"
             break
         fi

--- a/scripts/test_scripts/pqc_performance_test.sh
+++ b/scripts/test_scripts/pqc_performance_test.sh
@@ -712,9 +712,9 @@ function main() {
     # Main function for controlling the automated PQC computational performance testing using the Liboqs library.
 
     # Output the welcome message to the terminal
-    echo "###############################################################"
-    echo "PQC-Evaluation-Tools - Computational Performance Testing Suite"
-    echo -e "###############################################################\n"
+    echo "#################################################"
+    echo "PQC-LEO - Computational Performance Testing Suite"
+    echo -e "#################################################\n"
 
     # Set the default automatic result parsing flags
     parse_results=1

--- a/scripts/test_scripts/pqc_tls_performance_test.sh
+++ b/scripts/test_scripts/pqc_tls_performance_test.sh
@@ -342,11 +342,11 @@ function setup_base_env() {
     # Try and find the .dir_marker.tmp file to determine the project's root directory
     current_dir="$script_dir"
 
-    # Continue moving up the directory tree until the .pqc_eval_dir_marker.tmp file is found
+    # Continue moving up the directory tree until the .pqc_leo_dir_marker.tmp file is found
     while true; do
 
-        # Check if the .pqc_eval_dir_marker.tmp file is present
-        if [ -f "$current_dir/.pqc_eval_dir_marker.tmp" ]; then
+        # Check if the .pqc_leo_dir_marker.tmp file is present
+        if [ -f "$current_dir/.pqc_leo_dir_marker.tmp" ]; then
             root_dir="$current_dir"
             break
         fi

--- a/scripts/test_scripts/pqc_tls_performance_test.sh
+++ b/scripts/test_scripts/pqc_tls_performance_test.sh
@@ -1022,9 +1022,9 @@ function main() {
     # Main function for controlling automated TLS performance testing using PQC algorithms supported by OpenSSL and OQS-Provider
 
     # Output the welcome message to the terminal
-    echo "############################################################"
-    echo "PQC-Evaluation-Tools - Automated PQC TLS Performance Testing"
-    echo -e "############################################################\n"
+    echo "###############################################"
+    echo "PQC-LEO - Automated PQC TLS Performance Testing"
+    echo -e "###############################################\n"
 
     # Set the default global flag variables
     custom_control_time_flag="False"

--- a/scripts/test_scripts/tls_generate_keys.sh
+++ b/scripts/test_scripts/tls_generate_keys.sh
@@ -347,7 +347,7 @@ function main() {
 
     # Output the welcome message to the terminal
     echo "#########################################################"
-    echo "PQC-Evaluation-Tools - TLS Certificate & Key Generator"
+    echo "PQC-LEO - TLS Certificate & Key Generator"
     echo "Classic | PQC | Hybrid-PQC (OpenSSL 3.5.0 + OQS-Provider)"
     echo -e "#########################################################\n"
 

--- a/scripts/test_scripts/tls_generate_keys.sh
+++ b/scripts/test_scripts/tls_generate_keys.sh
@@ -20,11 +20,11 @@ function setup_base_env() {
     # Try and find the .dir_marker.tmp file to determine the project's root directory
     current_dir="$script_dir"
 
-    # Continue moving up the directory tree until the .pqc_eval_dir_marker.tmp file is found
+    # Continue moving up the directory tree until the .pqc_leo_dir_marker.tmp file is found
     while true; do
 
-        # Check if the .pqc_eval_dir_marker.tmp file is present
-        if [ -f "$current_dir/.pqc_eval_dir_marker.tmp" ]; then
+        # Check if the .pqc_leo_dir_marker.tmp file is present
+        if [ -f "$current_dir/.pqc_leo_dir_marker.tmp" ]; then
             root_dir="$current_dir"
             break
         fi

--- a/scripts/utility_scripts/configure_openssl_cnf.sh
+++ b/scripts/utility_scripts/configure_openssl_cnf.sh
@@ -113,11 +113,11 @@ function setup_base_env() {
     # Try and find the .dir_marker.tmp file to determine the project's root directory
     current_dir="$script_dir"
 
-    # Continue moving up the directory tree until the .pqc_eval_dir_marker.tmp file is found
+    # Continue moving up the directory tree until the .pqc_leo_dir_marker.tmp file is found
     while true; do
 
-        # Check if the .pqc_eval_dir_marker.tmp file is present
-        if [ -f "$current_dir/.pqc_eval_dir_marker.tmp" ]; then
+        # Check if the .pqc_leo_dir_marker.tmp file is present
+        if [ -f "$current_dir/.pqc_leo_dir_marker.tmp" ]; then
             root_dir="$current_dir"  # Set root_dir to the directory, not including the file name
             break
         fi

--- a/scripts/utility_scripts/get_algorithms.py
+++ b/scripts/utility_scripts/get_algorithms.py
@@ -56,12 +56,12 @@ def setup_base_env():
     # Determine the directory that the script is being executed from and set the marker filename
     script_dir = os.path.dirname(os.path.abspath(__file__))
     current_dir = script_dir
-    marker_filename = ".pqc_eval_dir_marker.tmp"
+    marker_filename = ".pqc_leo_dir_marker.tmp"
 
-    # Continue moving up the directory tree until the .pqc_eval_dir_marker.tmp file is found
+    # Continue moving up the directory tree until the .pqc_leo_dir_marker.tmp file is found
     while True:
 
-        # Check if the .pqc_eval_dir_marker.tmp file is present
+        # Check if the .pqc_leo_dir_marker.tmp file is present
         if os.path.isfile(os.path.join(current_dir, marker_filename)):
             root_dir = current_dir
             break

--- a/scripts/utility_scripts/source_code_modifier.sh
+++ b/scripts/utility_scripts/source_code_modifier.sh
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: MIT
 
 # This utility script provides internal source code modification utilities used exclusively by the main setup script 
-# in the PQC-evaluation-tools benchmarking suite. It is not intended to be executed manually. Instead, it is automatically
-# invoked during the setup process to modify source files in the OQS-Provider and OpenSSL libraries as required for
-# benchmarking configuration.
+# in the PQC-LEO benchmarking suite. It is not intended to be executed manually. Instead, it is automatically invoked 
+# during the setup process to modify source files in the OQS-Provider and OpenSSL libraries as required for benchmarking 
+# configuration.
 
 # The first argument passed to this script must always specify the modification tool to use (e.g., `oqs_enable_algs`
 # or `modify_openssl_src`). Subsequent arguments must include the required flags and values specific to the selected

--- a/scripts/utility_scripts/source_code_modifier.sh
+++ b/scripts/utility_scripts/source_code_modifier.sh
@@ -242,11 +242,11 @@ function setup_base_env() {
     # Try and find the .dir_marker.tmp file to determine the project's root directory
     current_dir="$script_dir"
 
-    # Continue moving up the directory tree until the .pqc_eval_dir_marker.tmp file is found
+    # Continue moving up the directory tree until the .pqc_leo_dir_marker.tmp file is found
     while true; do
 
-        # Check if the .pqc_eval_dir_marker.tmp file is present
-        if [ -f "$current_dir/.pqc_eval_dir_marker.tmp" ]; then
+        # Check if the .pqc_leo_dir_marker.tmp file is present
+        if [ -f "$current_dir/.pqc_leo_dir_marker.tmp" ]; then
             root_dir="$current_dir"  # Set root_dir to the directory, not including the file name
             break
         fi

--- a/setup.sh
+++ b/setup.sh
@@ -394,8 +394,8 @@ function configure_dirs() {
 
     done
 
-    # Create the hidden pqc_eval_dir_marker.tmp file that is used by the test scripts to determine the root directory path
-    touch "$root_dir/.pqc_eval_dir_marker.tmp"
+    # Create the hidden pqc_leo_dir_marker.tmp file that is used by the test scripts to determine the root directory path
+    touch "$root_dir/.pqc_leo_dir_marker.tmp"
 
     # If HQC is to be enabled, create the hqc_algorithms marker file in the temp directory
     if [ $enable_liboqs_hqc -eq 1 ] || [ $enable_oqs_hqc -eq 1 ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2023-2025 Callum Turino
 # SPDX-License-Identifier: MIT
 
-# This script automates the setup process for the PQC-evaluation-tools benchmarking suite. It provides options to build and configure
+# This script automates the setup process for the PQC-LEO benchmarking framework. It provides options to build and configure
 # the required cryptographic libraries (Liboqs, OQS-Provider, and OpenSSL) and their dependencies. The script handles directory
 # creation, dependency installation, library downloads, and compilation. It also allows customisation of build options,
 # such as enabling additional algorithms or modifying OpenSSL configurations. The script ensures compatibility
@@ -119,7 +119,7 @@ function output_help_message() {
 #-------------------------------------------------------------------------------------------------------------------------------
 function confirm_enable_hqc_algs() {
     # Temporary helper function for warning the user about the disabled HQC KEM algorithms as discussed in the issue
-    # (https://github.com/crt26/pqc-evaluation-tools/issues/46). The function will display a security warning and provide
+    # (https://github.com/crt26/PQC-LEO/issues/46). The function will display a security warning and provide
     # background information about why HQC KEM algorithms are disabled by default in Liboqs and OQS-Provider. It then 
     # prompts the user to decide whether to proceed with enabling HQC for benchmarking purposes. This function will be 
     # removed in the future when Liboqs version 0.14.0 is released and the HQC KEM algorithms are re-enabled by default.
@@ -142,8 +142,8 @@ function confirm_enable_hqc_algs() {
     
     echo -e "For more information, see:"
     echo -e "- https://github.com/open-quantum-safe/liboqs/issues/2118"
-    echo -e "- https://github.com/crt26/pqc-evaluation-tools/issues/46"
-    echo -e "- https://github.com/crt26/pqc-evaluation-tools/issues/60\n"
+    echo -e "- https://github.com/crt26/PQC-LEO/issues/46"
+    echo -e "- https://github.com/crt26/PQC-LEO/issues/60\n"
 
     # Prompt the user to acknowledge the risks and decide whether to proceed with enabling HQC KEM algorithms
     get_user_yes_no "Do you acknowledge the risks and wish to proceed with enabling HQC KEM algorithms?"
@@ -1095,13 +1095,13 @@ function setup_controller() {
 
 #-------------------------------------------------------------------------------------------------------------------------------
 function main() {
-    # Entry point for the PQC-Evaluation-Tools setup script. Initialises the environment, parses command-line arguments,
+    # Entry point for the PQC-LEO setup script. Initialises the environment, parses command-line arguments,
     # and delegates the setup process to the setup_controller function.
 
     # Output the welcome message to the terminal
-    echo "#################################"
-    echo "PQC-Evaluation-Tools Setup Script"
-    echo -e "#################################\n"
+    echo "####################"
+    echo "PQC-LEO Setup Script"
+    echo -e "####################\n"
 
     # Setup the base environment, global variables, and directory paths
     setup_base_env


### PR DESCRIPTION
## Summary

The repository will be renamed from pqc-evaluation-tools to PQC-LEO (PQC-Library Evaluation Operator). This requires updating all references to the old name across project documentation, code comments, and scripts so the new name is consistently reflected throughout the project.

## Task Details
- Rename the repository on GitHub to PQC-LEO
- Update all project documentation to use the new name
- Update inline documentation in scripts and code comments that reference the old name
- Update the name of the Git Project used to display the project's development cycle
- Create small mention in the main README for this version release so users are aware of the previous name